### PR TITLE
Support marking a link as part of an array

### DIFF
--- a/src/Halcyon/HAL/HALResponse.cs
+++ b/src/Halcyon/HAL/HALResponse.cs
@@ -139,8 +139,8 @@ namespace Halcyon.HAL {
 
             var grouped = resolved.GroupBy(r => r.Rel);
 
-            var singles = grouped.Where(g => g.Count() <= 1).ToDictionary(k => k.Key, v => v.SingleOrDefault() as object);
-            var lists = grouped.Where(g => g.Count() > 1).ToDictionary(k => k.Key, v => v.AsEnumerable() as object);
+            var singles = grouped.Where(g => g.Count() <= 1 && g.All(l => !l.IsRelArray)).ToDictionary(k => k.Key, v => v.SingleOrDefault() as object);
+            var lists = grouped.Where(g => g.Count() > 1 || g.Any(l => l.IsRelArray)).ToDictionary(k => k.Key, v => v.AsEnumerable() as object);
 
             var allLinks = singles.Concat(lists).ToDictionary(k => k.Key, v => v.Value);
 

--- a/src/Halcyon/HAL/Link.cs
+++ b/src/Halcyon/HAL/Link.cs
@@ -13,16 +13,20 @@ namespace Halcyon.HAL {
 
         private readonly bool replaceParameters;
 
-        public Link(string rel, string href, string title = null, string method = null, bool replaceParameters = true) {
+        public Link(string rel, string href, string title = null, string method = null, bool replaceParameters = true, bool isRelArray = false) {
             this.Rel = rel;
             this.Href = href;
             this.Title = title;
             this.Method = method;
             this.replaceParameters = replaceParameters;
+            this.IsRelArray = isRelArray;
         }
 
         [JsonIgnore]
         public string Rel { get; private set; }
+
+        [JsonIgnore]
+        public bool IsRelArray { get; private set; }
 
         [JsonProperty("href")]
         public string Href { get; private set; }

--- a/test/Halcyon.Tests/HAL/HALResponseTests.cs
+++ b/test/Halcyon.Tests/HAL/HALResponseTests.cs
@@ -144,6 +144,11 @@ namespace Halcyon.Tests.HAL {
                     personModel, new Link[] { new Link("a", "one"), new Link("a", "two"), new Link("b", "three") }, 
                     GetExpectedJson("\"_links\":{\"b\":{\"href\":\"three\"},\"a\":[{\"href\":\"one\"},{\"href\":\"two\"}]}"),
                     GetExpectedJson("")
+                },
+                new object[] {
+                    personModel, new Link[] { new Link("a", "one"), new Link("a", "two"), new Link("b", "three", isRelArray:true) },
+                    GetExpectedJson("\"_links\":{\"a\":[{\"href\":\"one\"},{\"href\":\"two\"}],\"b\":[{\"href\":\"three\"}]}"),
+                    GetExpectedJson("")
                 }
             };
         }

--- a/test/Halcyon.Tests/HAL/HALResponseTests.cs
+++ b/test/Halcyon.Tests/HAL/HALResponseTests.cs
@@ -149,6 +149,11 @@ namespace Halcyon.Tests.HAL {
                     personModel, new Link[] { new Link("a", "one"), new Link("a", "two"), new Link("b", "three", isRelArray:true) },
                     GetExpectedJson("\"_links\":{\"a\":[{\"href\":\"one\"},{\"href\":\"two\"}],\"b\":[{\"href\":\"three\"}]}"),
                     GetExpectedJson("")
+                },
+                new object[] {
+                    personModel, new Link[] { new Link("a", "one", isRelArray:true), new Link("a", "two"), new Link("b", "three") },
+                    GetExpectedJson("\"_links\":{\"b\":{\"href\":\"three\"},\"a\":[{\"href\":\"one\"},{\"href\":\"two\"}]}"),
+                    GetExpectedJson("")
                 }
             };
         }

--- a/test/Halcyon.Tests/HAL/LinkTests.cs
+++ b/test/Halcyon.Tests/HAL/LinkTests.cs
@@ -10,15 +10,16 @@ namespace Halcyon.Tests.HAL {
     public class LinkTests {
 
         [Theory]
-        [InlineData(null, null, null, null, null, null, null, null, null)]
-        [InlineData("", "", "", "", "", "", "", "", "")]
-        [InlineData("rel", "href", "title", "method", "type", "deprecation", "name", "profile", "hrefLang")]
-        public void Link_Created(string rel, string href, string title, string method, string type, string deprecation, string name, string profile, string hrefLang) {
+        [InlineData(null, null, null, null, null, null, null, null, null, false)]
+        [InlineData("", "", "", "", "", "", "", "", "", false)]
+        [InlineData("rel", "href", "title", "method", "type", "deprecation", "name", "profile", "hrefLang", true)]
+        public void Link_Created(string rel, string href, string title, string method, string type, string deprecation, string name, string profile, string hrefLang, bool isRelArray) {
             var link = new Link(
                 rel: rel,
                 href: href,
                 title: title,
-                method: method
+                method: method,
+                isRelArray: isRelArray
             ) {
                 Type = type,
                 Deprecation = deprecation,
@@ -35,6 +36,7 @@ namespace Halcyon.Tests.HAL {
             Assert.Equal(deprecation, link.Deprecation);
             Assert.Equal(name, link.Name);
             Assert.Equal(hrefLang, link.HrefLang);
+            Assert.Equal(isRelArray, link.IsRelArray);
         }
 
         [Theory]


### PR DESCRIPTION
This permits defining a link as part of an array - even if there is only a single link with that rel name.  Partially this was done to support following the recommendation from http://stateless.co/hal_specification.html:

> Note:
> If you're unsure whether the link should be singular, assume it will be multiple. If you pick singular and find you need to change it, you will need to create a new link relation or face breaking existing clients.

In particular, we intend to use this for adding curies to the _links array, as all examples of curies show them as an array of links, even when there is only a single link, e.g.

    "_links": {
      "curies": [
        {
          "name": "doc",
          "href": "http://haltalk.herokuapp.com/docs/{rel}",
          "templated": true
        }
      ],
    
      "doc:latest-posts": {
        "href": "/posts/latest"
      }
    }