### PR TITLE
application/json not handled by JsonHalOutputFormatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,10 +188,9 @@ public IServiceProvider ConfigureServices(IServiceCollection services) {
     services
       .AddMvc()
       .AddMvcOptions(c => {
-          var jsonOutputFormatter = new JsonOutputFormatter();
+          c.OutputFormatters.RemoveType<JsonOutputFormatter>();
           c.OutputFormatters.Add(new JsonHalOutputFormatter(
-              jsonOutputFormatter,
-              halJsonMediaTypes: new string[] { "application/hal+json", "application/vnd.example.hal+json", "application/vnd.example.hal.v1+json" }
+              new string[] { "application/hal+json", "application/vnd.example.hal+json", "application/vnd.example.hal.v1+json" }
           ));
       })
 }

--- a/test/Halcyon.Tests.SelfHost.Mvc/Startup.cs
+++ b/test/Halcyon.Tests.SelfHost.Mvc/Startup.cs
@@ -30,6 +30,7 @@ namespace Halcyon.Tests.SelfHost.Mvc {
             services
                 .AddMvc()
                 .AddMvcOptions(c => {
+                    c.OutputFormatters.RemoveType<JsonOutputFormatter>();
                     c.OutputFormatters.Add(new JsonHalOutputFormatter(
                         new string[] { "application/hal+json", "application/vnd.example.hal+json", "application/vnd.example.hal.v1+json" }
                     ));


### PR DESCRIPTION
Fix for https://github.com/visualeyes/halcyon/issues/47

In order for the JsonHalOutputFormatter to properly handle "application/json",
the default JsonOutputFormatter needs to be explicitly removed.
