### PR TITLE
Response Content-Type is always "application/json"

### DIFF
--- a/src/Halcyon.Mvc/HAL/Json/JsonHalOutputFormatter.cs
+++ b/src/Halcyon.Mvc/HAL/Json/JsonHalOutputFormatter.cs
@@ -7,6 +7,7 @@ using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Primitives;
 
 namespace Halcyon.Web.HAL.Json {
     public class JsonHalOutputFormatter : IOutputFormatter {
@@ -54,6 +55,7 @@ namespace Halcyon.Web.HAL.Json {
             }
 
             var jsonContext = new OutputFormatterWriteContext(context.HttpContext, context.WriterFactory, value.GetType(), value);
+            jsonContext.ContentType = new StringSegment(mediaType);
 
             await jsonFormatter.WriteAsync(jsonContext);
         }


### PR DESCRIPTION
Fix for https://github.com/visualeyes/halcyon/issues/51

Since the ContentType of the new OutputFormatterWriteContext is not set, the
JsonOutputFormatter defaults to "application/json".  Explicitly set that to
the type negotiated prior to invoking WriteAsync.