### PR TITLE
Unable to return non-HAL results after disabling default JsonOutputFormatter

### DIFF
--- a/src/Halcyon.Mvc/HAL/Json/JsonHalOutputFormatter.cs
+++ b/src/Halcyon.Mvc/HAL/Json/JsonHalOutputFormatter.cs
@@ -1,6 +1,5 @@
 ﻿using Halcyon.HAL;
 using Microsoft.AspNetCore.Mvc.Formatters;
-using Microsoft.Net.Http.Headers;
 using Newtonsoft.Json;
 using System;
 using System.Buffers;
@@ -16,7 +15,6 @@ namespace Halcyon.Web.HAL.Json {
         private readonly IEnumerable<string> halJsonMediaTypes;
         private readonly JsonOutputFormatter jsonFormatter;
         private readonly JsonSerializerSettings serializerSettings;
-
 
         public JsonHalOutputFormatter(IEnumerable<string> halJsonMediaTypes = null) {
             if(halJsonMediaTypes == null) halJsonMediaTypes = new string[] { HalJsonType };
@@ -37,14 +35,19 @@ namespace Halcyon.Web.HAL.Json {
         }
 
         public bool CanWriteResult(OutputFormatterCanWriteContext context) {
-            return context.ObjectType == typeof(HALResponse);
+            return context.ObjectType == typeof(HALResponse) || jsonFormatter.CanWriteResult(context);
         }
 
-        public async Task WriteAsync(OutputFormatterWriteContext context) {
+        public Task WriteAsync(OutputFormatterWriteContext context) {
+            var halResponse = context.Object as HALResponse;
+            if (halResponse == null)
+            {
+                return jsonFormatter.WriteAsync(context);
+            }
+
             string mediaType = context.ContentType.HasValue ? context.ContentType.Value : null;
 
             object value = null;
-            var halResponse = ((HALResponse)context.Object);
 
             // If it is a HAL response but set to application/json - convert to a plain response
             var serializer = JsonSerializer.Create(this.serializerSettings);
@@ -58,7 +61,7 @@ namespace Halcyon.Web.HAL.Json {
             var jsonContext = new OutputFormatterWriteContext(context.HttpContext, context.WriterFactory, value.GetType(), value);
             jsonContext.ContentType = new StringSegment(mediaType);
 
-            await jsonFormatter.WriteAsync(jsonContext);
+            return jsonFormatter.WriteAsync(jsonContext);
         }
     }
 }

--- a/src/Halcyon.Mvc/HAL/Json/JsonHalOutputFormatter.cs
+++ b/src/Halcyon.Mvc/HAL/Json/JsonHalOutputFormatter.cs
@@ -38,11 +38,12 @@ namespace Halcyon.Web.HAL.Json {
             return context.ObjectType == typeof(HALResponse) || jsonFormatter.CanWriteResult(context);
         }
 
-        public Task WriteAsync(OutputFormatterWriteContext context) {
+        public async Task WriteAsync(OutputFormatterWriteContext context) {
             var halResponse = context.Object as HALResponse;
             if (halResponse == null)
             {
-                return jsonFormatter.WriteAsync(context);
+                await jsonFormatter.WriteAsync(context);
+                return;
             }
 
             string mediaType = context.ContentType.HasValue ? context.ContentType.Value : null;
@@ -61,7 +62,7 @@ namespace Halcyon.Web.HAL.Json {
             var jsonContext = new OutputFormatterWriteContext(context.HttpContext, context.WriterFactory, value.GetType(), value);
             jsonContext.ContentType = new StringSegment(mediaType);
 
-            return jsonFormatter.WriteAsync(jsonContext);
+            await jsonFormatter.WriteAsync(jsonContext);
         }
     }
 }

--- a/test/Halcyon.Tests.SelfHost.Mvc/Controllers/PocoController.cs
+++ b/test/Halcyon.Tests.SelfHost.Mvc/Controllers/PocoController.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+namespace Halcyon.Tests.SelfHost.Mvc.Controllers {
+    [Route("api/[controller]")]
+    public class PocoController : Controller {
+
+        [HttpGet("{id:int}")]
+        public object Get(int id) {
+            // HALResponse is not required
+            return new {
+                id,
+                type = "POCO"
+            };
+        }
+    }
+}


### PR DESCRIPTION
Fix for https://github.com/visualeyes/halcyon/issues/54

Since we're replacing the JsonOutputFormatter, pass outputs that we can't handle (i.e. non-HALResponse types) to the JsonOutputFormatter.
