### PR TITLE
Check for null when converting embedded attributes.

### DIFF
--- a/src/Halcyon/HAL/Attributes/HALAttributeResolver.cs
+++ b/src/Halcyon/HAL/Attributes/HALAttributeResolver.cs
@@ -63,11 +63,15 @@ namespace Halcyon.HAL.Attributes {
                         return response; 
                     });
                 }
-                else
+                else if (modelValue != null)
                 {
                     var response = new HALResponse(modelValue, config);
                     AddEmbeddedResources(response, modelValue, config);
                     halResponses = new[] {response};
+                }
+                else
+                {
+                    continue;
                 }
 
                 yield return new HALEmbeddedItem(embeddAttribute.CollectionName, halResponses, embeddedItems != null); 

--- a/test/Halcyon.Tests/HAL/Attributes/EmbeddAttributeTests.cs
+++ b/test/Halcyon.Tests/HAL/Attributes/EmbeddAttributeTests.cs
@@ -71,5 +71,17 @@ namespace Halcyon.Tests.HAL {
 
             Assert.Equal("~/api/person?index=5", links["self"]["href"]);
         }
+
+        [Fact]
+        public void Embedded_Null_Enumerable_Constructed_From_Attribute() {
+            var model = new PersonModelWithNullEmbeddedAttribute();
+            var converter = new HALAttributeConverter();
+
+            var halResponse = converter.Convert(model);
+            var serializer = new JsonSerializer();
+            var jObject = halResponse.ToJObject(serializer);
+
+            Assert.Null(jObject["_embedded"]);
+        }
     }
 }

--- a/test/Halcyon.Tests/HAL/Models/PersonModelWithNullEmbeddedAttribute.cs
+++ b/test/Halcyon.Tests/HAL/Models/PersonModelWithNullEmbeddedAttribute.cs
@@ -1,0 +1,37 @@
+﻿using Halcyon.HAL.Attributes;
+using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace Halcyon.Tests.HAL.Models
+{
+    [HalModel("~/api", true)]
+    [HalLink("self", "person/{ID}")]
+    [HalLink("person", "person/{ID}")]
+    public class PersonModelWithNullEmbeddedAttribute
+    {
+        public const string TestModelJson = "\"ID\":1,\"FirstName\":\"fname\",\"LastName\":\"lname\",\"display_name\":\"fname lname\"";
+
+        public int ID { get; set; }
+
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+
+        [JsonProperty("display_name")]
+        public string DisplayName
+        {
+            get { return this.FirstName + " " + this.LastName; }
+        }
+
+        [JsonIgnore]
+        public string SpecialID
+        {
+            get { return this.DisplayName + "(" + this.ID + ")"; }
+        }
+
+        [HalEmbedded("pets")]
+        public List<Pet> Pets { get; set; }
+
+        [HalEmbedded("favouritePet")]
+        public Pet FavouritePet { get; set; }
+    }
+}


### PR DESCRIPTION
Check if embedded items are null before attempting to serialize them.
Without this check, a NullReferenceException is thrown when attempting
to convert a null value. Instead, the property will be ignored and not
included in the _embedded object if the object is null.

This is a proposed fix for the issue #65.